### PR TITLE
Fix install crash

### DIFF
--- a/libraries/IiifItems/Integration/Annotations.php
+++ b/libraries/IiifItems/Integration/Annotations.php
@@ -13,7 +13,7 @@ class IiifItems_Integration_Annotations extends IiifItems_BaseIntegration {
     public function install() {
         $elementTable = get_db()->getTable('Element');
         // Add Annotation item type elements
-        $annotation_metadata = insert_item_type(array(
+        $annotation_metadata = insert_item_type_failsafe(array(
             'name' => 'Annotation',
             'description' => 'An OA-compliant annotation',
         ), array(

--- a/libraries/IiifItems/Integration/Annotations.php
+++ b/libraries/IiifItems/Integration/Annotations.php
@@ -52,6 +52,7 @@ class IiifItems_Integration_Annotations extends IiifItems_BaseIntegration {
         delete_option('iiifitems_annotation_selector_element');
         delete_option('iiifitems_annotation_xywh_element');
         delete_option('iiifitems_annotation_elements');
+        delete_option('iiifitems_annotation_text_element');
     }
     
     /**

--- a/libraries/IiifItems/Integration/Collections.php
+++ b/libraries/IiifItems/Integration/Collections.php
@@ -57,6 +57,7 @@ class IiifItems_Integration_Collections extends IiifItems_BaseIntegration {
         delete_option('iiifitems_collection_atid_element');
         delete_option('iiifitems_collection_type_element');
         delete_option('iiifitems_collection_json_element');
+        delete_option('iiifitems_collection_uuid_element');
     }
     
     /**

--- a/libraries/IiifItems/Integration/Collections.php
+++ b/libraries/IiifItems/Integration/Collections.php
@@ -31,7 +31,7 @@ class IiifItems_Integration_Collections extends IiifItems_BaseIntegration {
     public function install() {
         $elementTable = get_db()->getTable('Element');
         // Add Collection type metadata elements
-        $collection_metadata = insert_element_set(array(
+        $collection_metadata = insert_element_set_failsafe(array(
             'name' => 'IIIF Collection Metadata',
             'description' => '',
             'record_type' => 'Collection'

--- a/libraries/IiifItems/Integration/Files.php
+++ b/libraries/IiifItems/Integration/Files.php
@@ -16,7 +16,7 @@ class IiifItems_Integration_Files extends IiifItems_BaseIntegration {
     public function install() {
         $elementTable = get_db()->getTable('Element');
         // Add File type metadata elements
-        $file_metadata = insert_element_set(array(
+        $file_metadata = insert_element_set_failsafe(array(
             'name' => 'IIIF File Metadata',
             'description' => '',
             'record_type' => 'File'

--- a/libraries/IiifItems/Integration/Items.php
+++ b/libraries/IiifItems/Integration/Items.php
@@ -33,7 +33,7 @@ class IiifItems_Integration_Items extends IiifItems_BaseIntegration {
     public function install() {
         $elementTable = get_db()->getTable('Element');
         // Add Item type metadata elements
-        $item_metadata = insert_element_set(array(
+        $item_metadata = insert_element_set_failsafe(array(
             'name' => 'IIIF Item Metadata',
             'description' => '',
             'record_type' => 'Item'

--- a/libraries/IiifItems/Integration/Items.php
+++ b/libraries/IiifItems/Integration/Items.php
@@ -59,6 +59,7 @@ class IiifItems_Integration_Items extends IiifItems_BaseIntegration {
         delete_option('iiifitems_item_display_element');
         delete_option('iiifitems_item_atid_element');
         delete_option('iiifitems_item_json_element');
+        delete_option('iiifitems_item_uuid_element');
     }
     
     /**

--- a/libraries/IiifItems/Migration/0_0_1_6.php
+++ b/libraries/IiifItems/Migration/0_0_1_6.php
@@ -14,12 +14,19 @@ class IiifItems_Migration_0_0_1_6 extends IiifItems_BaseMigration {
     public function up() {
         // Add elements
         $collectionElementSet = get_record_by_id('ElementSet', get_option('iiifitems_collection_element_set'));
-        $collectionElementSet->addElements(array('UUID'));
-        $collectionElementSet->save();
+        try {
+            $collectionElementSet->addElements(array('UUID'));
+            $collectionElementSet->save();
+        } catch (Omeka_Validate_Exception $ex) {
+            debug("Passed UUID element for collections.");
+        }
         $itemElementSet = get_record_by_id('ElementSet', get_option('iiifitems_item_element_set'));
-        $itemElementSet->addElements(array('UUID'));
-        $itemElementSet->save();
-        
+        try {
+            $itemElementSet->addElements(array('UUID'));
+            $itemElementSet->save();
+        } catch (Omeka_Validate_Exception $ex) {
+            debug("Passed UUID element for items.");
+        }
         // Set quick-access options
         $tableElement = get_db()->getTable('Element');
         $uuidCollectionElement = $tableElement->findByElementSetNameAndElementName($collectionElementSet->name, 'UUID');


### PR DESCRIPTION
This PR adds a substitute fail-safe version of ```insert_element_set()``` and ```insert_item_type()``` to install metadata elements. It allows interrupted installations to resume safely without "Name: Name of element set must be unique." validation errors.