### PR TITLE
Fix urlencode() PHP warning when submitting an import request

### DIFF
--- a/controllers/ImportController.php
+++ b/controllers/ImportController.php
@@ -25,7 +25,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         // Process the form instead if POSTed
         if ($this->getRequest()->isPost()) {
             if ($this->processSubmission()) {
-                $this->_helper->redirector->goto(array(), 'status');
+                $this->_helper->redirector->gotoRoute(array(), 'iiifItemsStatus');
             }
         }
     }


### PR DESCRIPTION
Change the redirection routine on ```IiifItems_ImportController::formAction()``` to avoid the following warning (#5):

```[Tue Aug 08 08:32:06.307874 2017] [:error] [pid 1142] [client xx.xx.xx.xx:59351] PHP Warning: urlencode() expects parameter 1 to be string, array given in /var/www/omeka241/application/libraries/Zend/Controller/Router/Route/Module.php on line 279, referer: https://omeka.ucalgary.ca/admin/iiif-items/import```