### PR TITLE
No Mirador for images when IIIF bridge is unset

### DIFF
--- a/libraries/IiifItems/Integration/Items.php
+++ b/libraries/IiifItems/Integration/Items.php
@@ -24,7 +24,7 @@ class IiifItems_Integration_Items extends IiifItems_BaseIntegration {
      * @return boolean
      */
     protected function _isntIiifDisplayableItem($item) {
-        return ($item->fileCount() == 0 && !$item->hasElementText('IIIF Item Metadata', 'JSON Data')) || IiifItems_Util_Canvas::isNonIiifItem($item);
+        return (($item->fileCount() == 0 || get_option('iiifitems_bridge_prefix') == "") && !$item->hasElementText('IIIF Item Metadata', 'JSON Data')) || IiifItems_Util_Canvas::isNonIiifItem($item);
     }
     
     /**


### PR DESCRIPTION
If an Item has files, but there is no IIIF bridge set up, there shouldn't be a IIIF viewer displayed unless the Item has IIIF JSON data associated with it.

Previously, if there were no bridge set up, Items without manifests would display an empty Mirador viewer as long as they had IIIF-compatible files associated with them.

I found this out on a site where we don't have a IIIF server set up, but we still want to take advantage of externally hosted IIIF-compatible images and annotate those, while also having images that we had uploaded ourselves.