### PR TITLE
allow image height and width to be set in annotations

### DIFF
--- a/views/shared/js/mirador/mirador.js
+++ b/views/shared/js/mirador/mirador.js
@@ -43433,7 +43433,7 @@ $.SearchWithinResults.prototype = {
       allowedTags: ['a', 'b', 'br', 'i', 'img', 'p', 'span', 'strong', 'em', 'u', 'ul', 'ol', 'li'],
       allowedAttributes: {
         'a': ['href', 'target'],
-        'img': ['src', 'alt'],
+        'img': ['src', 'alt', 'width', 'height'],
         'ul': ['type'],
         'ol': ['type'],
         'p': ['style', 'dir'],


### PR DESCRIPTION
This implements the fix suggested by @dicksonlaw583 in issue #18 about images in annotations. This works on our installation, so it may be that other folks would benefit from the change.