### PR TITLE
Put glue before array in all join() calls

### DIFF
--- a/libraries/IiifItems/IiifUtil.php
+++ b/libraries/IiifItems/IiifUtil.php
@@ -57,19 +57,19 @@ class IiifItems_IiifUtil {
         ));
         if (isset($elements['Dublin Core'])) {
             if (isset($elements['Dublin Core']['Title'])) {
-                $jsonData['label'] = join($elements['Dublin Core']['Title'], ' ');
+                $jsonData['label'] = join(' ', $elements['Dublin Core']['Title']);
                 unset($elements['Dublin Core']['Title']);
             }
             if (isset($elements['Dublin Core']['Description'])) {
-                $jsonData['description'] = join($elements['Dublin Core']['Description'], '<br>');
+                $jsonData['description'] = join('<br>', $elements['Dublin Core']['Description']);
                 unset($elements['Dublin Core']['Description']);
             }
             if (isset($elements['Dublin Core']['Publisher'])) {
-                $jsonData['attribution'] = join($elements['Dublin Core']['Publisher'], '<br>');
+                $jsonData['attribution'] = join('<br>', $elements['Dublin Core']['Publisher']);
                 unset($elements['Dublin Core']['Publisher']);
             }
             if (isset($elements['Dublin Core']['Rights'])) {
-                $jsonData['license'] = join($elements['Dublin Core']['Rights'], '<br>');
+                $jsonData['license'] = join('<br>', $elements['Dublin Core']['Rights']);
                 unset($elements['Dublin Core']['Rights']);
             }
             if (!empty($elements['Dublin Core'])) {
@@ -79,7 +79,7 @@ class IiifItems_IiifUtil {
                 foreach ($elements['Dublin Core'] as $elementName => $elementContent) {
                     $jsonData['metadata'][] = array(
                         'label' => $elementName,
-                        'value' => join($elementContent, '<br>')
+                        'value' => join('<br>', $elementContent)
                     );
                 }
             }

--- a/libraries/IiifItems/Migration/0_0_1_7.php
+++ b/libraries/IiifItems/Migration/0_0_1_7.php
@@ -14,7 +14,7 @@ class IiifItems_Migration_0_0_1_7 extends IiifItems_BaseMigration {
     public function up() {
         // Copy over placeholder images
         $storage = Zend_Registry::get('storage');
-        $placeholderDir = join(array(__DIR__, '..', '..', '..', 'placeholders'), DIRECTORY_SEPARATOR);
+        $placeholderDir = join(DIRECTORY_SEPARATOR, array(__DIR__, '..', '..', '..', 'placeholders'));
         foreach (array_diff(scandir($placeholderDir), array('.', '..')) as $fname) {
             try {
                 copy($placeholderDir . DIRECTORY_SEPARATOR . $fname, $storage->getTempDir() . DIRECTORY_SEPARATOR . $fname);
@@ -29,7 +29,7 @@ class IiifItems_Migration_0_0_1_7 extends IiifItems_BaseMigration {
     public function uninstall() {
         // Uninstall placeholder images
         $storage = Zend_Registry::get('storage');
-        $placeholderDir = join(array(__DIR__, '..', '..', '..', 'placeholders'), DIRECTORY_SEPARATOR);
+        $placeholderDir = join(DIRECTORY_SEPARATOR, array(__DIR__, '..', '..', '..', 'placeholders'));
         foreach (array_diff(scandir($placeholderDir), array('.', '..')) as $fname) {
             try {
                 $storage->delete($storage->getPathByType($fname, 'original'));

--- a/libraries/IiifItems/Util/Annotation.php
+++ b/libraries/IiifItems/Util/Annotation.php
@@ -298,7 +298,7 @@ class IiifItems_Util_Annotation extends IiifItems_IiifUtil {
             'resource' => array(
                 '@type' => 'dctypes:Text',
                 'format' => 'text/html',
-                'chars' => '<ul><li>' . join($fileLinks, '</li><li>') . '</li></ul>'
+                'chars' => '<ul><li>' . join('</li><li>', $fileLinks) . '</li></ul>'
             ),
         ));
     }


### PR DESCRIPTION
Put the separator first in all `join()` calls to avoid deprecation error in PHP 7.4.

For #21.