### PR TITLE
Code more defensively when accessing current_user()

### DIFF
--- a/controllers/ImportController.php
+++ b/controllers/ImportController.php
@@ -5,11 +5,11 @@
  * @package controllers
  */
 class IiifItems_ImportController extends IiifItems_BaseController {
-    
+
     /**
      * Renders the IIIF import form if on GET, receives submission if on POST.
      * GET/POST iiif-items/import
-     * 
+     *
      * @throws Omeka_Controller_Exception_404
      */
     public function formAction() {
@@ -17,11 +17,11 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         if (!is_admin_theme() || current_user()->role == 'researcher') {
             throw new Omeka_Controller_Exception_404;
         }
-        
+
         // Render the form
         $form = $this->_getImportForm();
         $this->view->form = $form;
-        
+
         // Process the form instead if POSTed
         if ($this->getRequest()->isPost()) {
             if ($this->processSubmission()) {
@@ -29,11 +29,11 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             }
         }
     }
-    
+
     /**
      * Processes the submission of the IIIF import form.
      * POST iiif-items/import
-     * 
+     *
      * @return boolean
      */
     protected function processSubmission() {
@@ -52,7 +52,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
                 $this->_helper->flashMessenger(__('Inaccessible parent.'), 'error');
                 return false;
             }
-            if ($currentUser->role == 'contributor' && $parentUuid && $parentCollection->owner_id != $currentUser->id) {
+            if ($currentUser && $currentUser->role == 'contributor' && $parentUuid && $parentCollection->owner_id != $currentUser->id) {
                 $this->_helper->flashMessenger(__("You may not import into another user's collections as a contributor."), 'error');
                 return false;
             }
@@ -96,7 +96,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
                 case 1:
                     $importSource = 'Url';
                     $importSourceBody = $this->_extractResourceUrl($form->getValue('items_import_source_url'));
-                    
+
                 break;
                 case 2:
                     $importSource = 'Paste';
@@ -160,7 +160,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             return false;
         }
     }
-    
+
     /**
      * Attempts to return the manifest URL from IIIF drag-and-drop URLs
      * @param string $url
@@ -181,11 +181,11 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         // Still nothing, just give back the URL
         return $url;
     }
-    
+
     /**
      * Renders a table of job statuses related to IIIF Toolkit.
      * GET iiif-items/status
-     * 
+     *
      * @throws Omeka_Controller_Exception_404
      */
     public function statusAction() {
@@ -198,14 +198,14 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         $this->view->statuses = $table->fetchObjects('SELECT * FROM ' . $table->getTableName() . ' ORDER BY added DESC');
         $this->view->t = date_timestamp_get(new DateTime());
     }
-    
+
     /**
      * Renders JSON with current server timestamp and list of import tasks updated since the specified last-updated timestamp
      * AJAX call for the auto-update in the status page
      * GET iiif-items/status-update?t=...
-     * 
+     *
      * { "t": ..., "updates": [{TASK}, {TASK}, ...] }
-     * 
+     *
      * @throws Omeka_Controller_Exception_404
      */
     public function statusUpdateAction() {
@@ -213,7 +213,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         if (!is_admin_theme() || current_user()->role == 'researcher') {
             throw new Omeka_Controller_Exception_404();
         }
-        
+
         if (!isset($_GET['t'])) {
             throw new Omeka_Controller_Exception_404();
         }
@@ -226,7 +226,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         $jsonData['updates'] = $table->fetchAll($updatesSelect, array(date('Y-m-d H:i:s', $_GET['t'])));
         $this->__respondWithJson($jsonData);
     }
-    
+
     /**
      * Helper for returning the import form
      * @return IiifItems_Form_Import
@@ -235,11 +235,11 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         $form = new IiifItems_Form_Import();
         return $form;
     }
-    
+
     /**
      * Repair the preview images of the given item.
      * POST iiif-items/items/:id/repair
-     * 
+     *
      * @throws Omeka_Controller_Exception_404
      */
     public function repairItemAction() {
@@ -292,7 +292,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             // Non-annotation item
             else {
                 $jsonData = json_decode($jsonStr, true);
-                foreach ($jsonData['images'] as $image) { 
+                foreach ($jsonData['images'] as $image) {
                     $downloader = new IiifItems_ImageDownloader($image);
                     $file = $downloader->downloadToItem($item, 'full');
                 }
@@ -309,7 +309,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
         $this->_helper->flashMessenger(__("Item successfully repaired. Please recheck contents."));
         Zend_Controller_Action_HelperBroker::getStaticHelper('redirector')->gotoUrl($returnUrl);
     }
-    
+
     /**
      * Renders the maintenance actions menu.
      * GET iiif-items/maintenance
@@ -320,12 +320,12 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             throw new Omeka_Controller_Exception_404();
         }
     }
-    
+
     /**
      * Cleans cached data generated by the IIIF Toolkit plugin.
      * Pass type=all, id=all to clear all cached data.
      * Pass record type and ID to clear cached data for that record
-     * 
+     *
      * POST iiif-items/clean-cache
      */
     public function cleanCacheAction() {
@@ -335,13 +335,13 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             throw new Omeka_Controller_Exception_404();
         }
         $this->__restrictVerb('POST');
-        
+
         // Set up request
         $request = $this->getRequest();
         $targetType = $this->getParam('type');
         $targetId = $this->getParam('id');
         $db = get_db();
-        
+
         // Clear all
         if ($targetType == 'all' && $targetId == 'all') {
             $db->query("TRUNCATE `{$db->prefix}iiif_items_cached_json_data`;");
@@ -358,7 +358,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
                     $db->query("DELETE FROM `{$db->prefix}iiif_items_cached_json_data` WHERE record_id = ? AND record_type = ?;", array($targetId, $targetType));
                     $this->_helper->flashMessenger(__("Cleaned JSON cached data."));
                     switch (get_class($target)) {
-                        case 'Collection': 
+                        case 'Collection':
                             $targetUrl = $request->getServer('HTTP_REFERER', WEB_ROOT . admin_url(array(
                                 'controller' => 'collections',
                                 'action' => 'show',
@@ -372,8 +372,8 @@ class IiifItems_ImportController extends IiifItems_BaseController {
                                 'id' => $targetId,
                             ), 'id'));
                         break;
-                        default: 
-                            $targetUrl = $request->getServer('HTTP_REFERER', WEB_ROOT . admin_url()); 
+                        default:
+                            $targetUrl = $request->getServer('HTTP_REFERER', WEB_ROOT . admin_url());
                         break;
                     }
                     Zend_Controller_Action_HelperBroker::getStaticHelper('redirector')->gotoUrl($targetUrl);
@@ -383,7 +383,7 @@ class IiifItems_ImportController extends IiifItems_BaseController {
             catch (Exception $e) {
             }
         }
-        
+
         // Fail
         $this->_helper->flashMessenger(__("Failed to purge JSON cache"));
     }

--- a/libraries/IiifItems/Form/Import.php
+++ b/libraries/IiifItems/Form/Import.php
@@ -1,6 +1,6 @@
 <?php
 
-// TODO: Validation 
+// TODO: Validation
 //    - Type must be filled
 //    - If From File is checked, items_import_source_file must be filled
 //    - If From URL is filled, the URL must be correctly formatted and filled
@@ -45,9 +45,10 @@ class IiifItems_Form_Import extends Omeka_Form {
             'label' => __('JSON Data'),
         ));
         // Parent
+        $currentUser = current_user();
         $this->addElement('select', 'items_import_to_parent', array(
             'label' => __('Parent'),
-            'multiOptions' => IiifItems_Util_CollectionOptions::getFullOptions(null, (current_user()->role == 'contributor') ? current_user() : null),
+            'multiOptions' => IiifItems_Util_CollectionOptions::getFullOptions(null, ($currentUser && $currentUser->role == 'contributor') ? $currentUser : null),
         ));
         // Set to Public?
         $this->addElement('checkbox', 'items_are_public', array(
@@ -71,7 +72,7 @@ class IiifItems_Form_Import extends Omeka_Form {
                 'use_hidden_element' => false,
             ),
         ));
-        // Local Preview Size 
+        // Local Preview Size
         $this->addElement('radio', 'items_preview_size', array(
             'label' => __('Local Preview Size'),
             'multiOptions' => array('None', '96x96', '512x512', 'Maximum'),
@@ -89,7 +90,7 @@ class IiifItems_Form_Import extends Omeka_Form {
         $submit->setDecorators(array(
             'ViewHelper', array(
                 'HtmlTag', array(
-                    'tag' => 'div', 
+                    'tag' => 'div',
                     'class' => 'field'
                 )
             )

--- a/libraries/IiifItems/Integration/System.php
+++ b/libraries/IiifItems/Integration/System.php
@@ -11,7 +11,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         'public_navigation_main',
         'display_elements',
     );
-    
+
     /**
      * General installation procedures.
      */
@@ -50,7 +50,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
             `generated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
     }
-    
+
     /**
      * Add IIIF settings entries.
      */
@@ -60,7 +60,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         $addCssAndJsMigration = new IiifItems_Migration_0_0_1_9();
         $addCssAndJsMigration->up();
     }
-    
+
     /**
      * Copy placeholders for non-IIIF content into /files/originals.
      */
@@ -68,7 +68,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         $addMediaPlaceholdersMigration = new IiifItems_Migration_0_0_1_7();
         $addMediaPlaceholdersMigration->up();
     }
-    
+
     /**
      * Start job that adds UUIDs to existing collections, items and files.
      */
@@ -76,7 +76,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         $addUuidElementMigration = new IiifItems_Migration_0_0_1_6();
         $addUuidElementMigration->up();
     }
-    
+
     /**
      * Add viewing options.
      */
@@ -87,7 +87,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         set_option('iiifitems_show_mirador_items', 1);
         set_option('iiifitems_show_mirador_files', 1);
     }
-    
+
     /**
      * Removes IIIF Toolkit-specific elements.
      */
@@ -97,7 +97,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         $this->__removeMediaPlaceholders();
         $this->__removeViewOptions();
     }
-    
+
     /**
      * Drop tables for IIIF Toolkit-specific models.
      */
@@ -106,7 +106,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         $db->query("DROP TABLE IF EXISTS `{$db->prefix}iiif_items_job_statuses`;");
         $db->query("DROP TABLE IF EXISTS `{$db->prefix}iiif_items_cached_json_data`;");
     }
-    
+
     /**
      * Delete IIIF settings.
      */
@@ -116,7 +116,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         delete_option('iiifitems_mirador_css');
         delete_option('iiifitems_mirador_js');
     }
-    
+
     /**
      * Delete placeholder images for non-IIIF content from /files/originals.
      */
@@ -140,7 +140,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
             }
         }
     }
-    
+
     /**
      * Remove viewing options.
      */
@@ -151,18 +151,19 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         delete_option('iiifitems_show_mirador_items');
         delete_option('iiifitems_show_mirador_files');
     }
-    
+
     /**
      * Filter for the main admin navigation.
      * Adds navigation link to the IIIF Toolkit import form, status screen and maintenance options.
      * Also add IIIF Catalogue Tree
-     * 
+     *
      * @param array $nav
      * @return array
      */
     public function filterAdminNavigationMain($nav) {
         // Add link to import form, status screen, etc. to qualified users
-        if (current_user()->role != 'researcher') {
+        $currentUser = current_user();
+        if ($currentUser && $currentUser->role != 'researcher') {
             $nav[] = array(
                 'label' => __('IIIF Toolkit'),
                 'uri' => url('iiif-items/import'),
@@ -181,11 +182,11 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
         // Return navigation
         return $nav;
     }
-    
+
     /**
      * Filter for the public navigation menu.
      * Add the catalogue tree link.
-     * 
+     *
      * @param array $nav
      * @return array
      */
@@ -204,7 +205,7 @@ class IiifItems_Integration_System extends IiifItems_BaseIntegration {
     /**
      * Filter for which elements to display.
      * Unset most IIIF Toolkit-specific metadata for manual handling.
-     * 
+     *
      * @param array $elementsBySet
      * @return array
      */


### PR DESCRIPTION
The `current_user()` method returns null if the user is anonymous. With the previous implementation, one would see frequent warnings such as this in PHP logs.

`PHP Warning:  Attempt to read property "role" on null`

This update adds checks to ensure that the current user is not null before attempting to access its properties.

I didn't update the instances of this method's use in `views/admin/mirador/annotator.php` because I figured it should be impossible to reach that code if you are not logged in.

My editor also removed all trailing whitespace.