### PR TITLE
Update Collections.php

### DIFF
--- a/libraries/IiifItems/Integration/Collections.php
+++ b/libraries/IiifItems/Integration/Collections.php
@@ -513,10 +513,16 @@ EOF;
      * @param array Search options for collections.
      * @return array Filtered search options for collections.
      */
-    public function filterCollectionsSelectOptions($options)
-    {
-        $currentUser = current_user();
-        $treeOptions = IiifItems_Util_CollectionOptions::getFullIdOptions(null, ($currentUser && $currentUser->role == 'contributor') ? $currentUser : null);
-        return array_intersect_key($treeOptions, $options);
+public function filterCollectionsSelectOptions($options){
+    $currentUser = current_user();
+    // Check if the user is logged in
+    if ($currentUser) {
+        $treeOptions = IiifItems_Util_CollectionOptions::getFullIdOptions(null, ($currentUser->role == 'contributor') ? $currentUser : null);
+    } else { // if not logged in, only show public collections
+        $treeOptions = IiifItems_Util_CollectionOptions::getFullIdOptions(true, null);
     }
+
+    return array_intersect_key($treeOptions, $options);
+    }
+
 }


### PR DESCRIPTION
We were getting a lot of errors similar to 
`[Mon` Oct 14 08:47:08.271800 2024] [php:warn] [pid 1359466] [client 10.144.25.41:43240] PHP Warning:  Attempt to read property "role" on null in /var/www/html/omeka/plugins/IiifItems/libraries/IiifItems/Integration/Collections.php on line 519

in our apache logs. This error was also showing up in the UI. We tracked the issue down to 'users that were not logged in, accessing the advanced search page' (this page: https://archives.library.wcsu.edu/omeka/items/search ).

This change defaults the collections drop-down to only showing public collections for not-logged-in users.

